### PR TITLE
Automated instantiation and binding of Paths in EdgeMovements.

### DIFF
--- a/Assets/Prefabs/MovementTrigger.prefab
+++ b/Assets/Prefabs/MovementTrigger.prefab
@@ -52,7 +52,7 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000013535477542}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -151,4 +151,4 @@ MonoBehaviour:
   InactiveMaterial: {fileID: 2100000, guid: 0edec395166a3244592f3532c7ce794c, type: 2}
   GazedAtMaterial: {fileID: 2100000, guid: daad62324deb0cf448e5c805c8459bff, type: 2}
   OverridePlacement: 0
-  DistanceToNode: 2
+  DistanceToNode: 3

--- a/Assets/Scripts/Editor/NavGraphBuilder.cs
+++ b/Assets/Scripts/Editor/NavGraphBuilder.cs
@@ -1,16 +1,65 @@
-﻿using System;
-using UnityEngine;
-using System.Collections;
+﻿using UnityEngine;
 using SWS;
+using UnityEditor;
 
 public class NavGraphBuilder : MonoBehaviour {
 
     public static void UpdateSpline(NavGraphEdgeMovement target)
     {
+        string edgeNumber = target.name.Split('_')[1];
+
         Debug.Log("Update spline of " + target.name);
-        target.PathContainer.gameObject.transform.GetChild(0).transform.position = 
+
+        if (target.PathContainer == null)
+        {
+            WaypointManager waypointManager = target.transform.parent.GetComponentInChildren<WaypointManager>();
+            PathManager[] pathManagers = waypointManager.transform.GetComponentsInChildren<PathManager>();
+
+            foreach (PathManager pathManager in pathManagers)
+            {
+                if (pathManager.name == "Path_" + edgeNumber)
+                {
+                    target.PathContainer = pathManager;
+                    break;
+                }
+            }
+
+            if (target.PathContainer == null)
+            {
+                // Instantiate a new Path container as a child of waypointManager
+
+                //create a new container transform which will hold all new waypoints
+                GameObject pathContainer = new GameObject();
+                //reset position and parent container gameobject to this manager gameobject
+                pathContainer.transform.position = waypointManager.gameObject.transform.position;
+                pathContainer.transform.parent = waypointManager.gameObject.transform;
+                pathContainer.name = "Path_" + edgeNumber;
+
+                //create new waypoint gameobject
+                GameObject waypoint_start = new GameObject("Waypoint 0");
+                GameObject waypoint_end = new GameObject("Waypoint 1");
+                waypoint_start.transform.parent = pathContainer.transform;
+                waypoint_end.transform.parent = pathContainer.transform;
+
+                //Undo.RegisterCreatedObjectUndo(waypoint_start, "Created waypoint_start");
+                //Undo.RegisterCreatedObjectUndo(waypoint_end, "Created waypoint_end");
+
+                target.PathContainer = pathContainer.AddComponent<PathManager>();
+                target.PathContainer.waypoints = new Transform[2];
+                target.PathContainer.waypoints[0] = waypoint_start.transform;
+                target.PathContainer.waypoints[1] = waypoint_end.transform;
+
+                WaypointManager.AddPath(pathContainer);
+            }
+            target.PathContainer.name = "Path_" + edgeNumber;
+        }
+
+        target.PathContainer.gameObject.transform
+        .FindChild(target.PathContainer.waypoints[0].name).transform.position = 
             target.StartNode.transform.position;
-        target.PathContainer.gameObject.transform.GetChild(target.PathContainer.waypoints.Length - 1).transform.position =
+
+        target.PathContainer.gameObject.transform
+        .FindChild(target.PathContainer.waypoints[target.PathContainer.waypoints.Length - 1].name).transform.position =
             target.EndNode.transform.position;
 
         EditorUtility.SetDirty(target);
@@ -26,7 +75,10 @@ public class NavGraphBuilder : MonoBehaviour {
             foreach (NavGraphEdgeTrigger edgeTrigger in edgesTriggers)
             {
                 if (edgeTrigger.EdgeMovement == target)
+                {
                     target.startTrigger = edgeTrigger;
+                    break;
+                }
             }
 
             if (target.startTrigger == null)
@@ -45,7 +97,10 @@ public class NavGraphBuilder : MonoBehaviour {
             foreach (NavGraphEdgeTrigger edgeTrigger in edgesTriggers)
             {
                 if (edgeTrigger.EdgeMovement == target)
+                {
                     target.endTrigger = edgeTrigger;
+                    break;
+                }
             }
 
             if (target.endTrigger == null)
@@ -57,7 +112,6 @@ public class NavGraphBuilder : MonoBehaviour {
 
             target.endTrigger.name = "EdgeTrigger_" + edgeNumber + "_R";
         }
-
 
         // Set the start and end triggers
         Vector3[] pathPoints = WaypointManager.GetCurved(target.PathContainer.GetPathPoints());

--- a/Assets/Scripts/Editor/NavGraphBuilder.cs
+++ b/Assets/Scripts/Editor/NavGraphBuilder.cs
@@ -12,6 +12,8 @@ public class NavGraphBuilder : MonoBehaviour {
             target.StartNode.transform.position;
         target.PathContainer.gameObject.transform.GetChild(target.PathContainer.waypoints.Length - 1).transform.position =
             target.EndNode.transform.position;
+
+        EditorUtility.SetDirty(target);
     }
 
     public static void UpdateTriggers(NavGraphEdgeMovement target)
@@ -73,6 +75,8 @@ public class NavGraphBuilder : MonoBehaviour {
             float distance = target.endTrigger.DistanceToNode;
             target.endTrigger.transform.position = target.EndNode.transform.position + endTangent * distance;
         }
+
+        EditorUtility.SetDirty(target);
     }
 
     public static void UpdateSplines(NavGraphManager target)

--- a/Assets/Scripts/NavGraphEdgeMovement.cs
+++ b/Assets/Scripts/NavGraphEdgeMovement.cs
@@ -21,6 +21,9 @@ public class NavGraphEdgeMovement : MonoBehaviour {
 
     void OnDrawGizmos()
     {
+        if(PathContainer == null || PathContainer.GetPathPoints().Length < 2)
+            return;
+
         Gizmos.color = Color.yellow;
         WaypointManager.DrawCurved(PathContainer.GetPathPoints());
     }

--- a/Assets/Scripts/NavGraphEdgeMovement.cs
+++ b/Assets/Scripts/NavGraphEdgeMovement.cs
@@ -6,8 +6,12 @@ using UnityEngine.Events;
 public class NavGraphEdgeMovement : MonoBehaviour {
 
     // Reference to path
+    [SerializeField]
     public PathManager PathContainer;
-    public NavGraphEdgeTrigger startTrigger, endTrigger;
+    [SerializeField]
+    public NavGraphEdgeTrigger startTrigger;
+    [SerializeField]
+    public NavGraphEdgeTrigger endTrigger;
 
     public NavGraphNode StartNode;
     public NavGraphNode EndNode;


### PR DESCRIPTION
Removed another dull task in setting up a NavGraph.
We still need of course to manually create and place any needed intermediate waypoints in the Paths, but this part is handled nicely with the SWS.Pathmanager editor.

At this point, the work to set up a NavGraph looks like this :
1 - Place the Nodes
2 - Set up the EdgeMovements, link them to their start and end Nodes
3 - Click on "Update Splines" to generate all the needed Paths and EdgeTriggers
-> At this point we have a functional NavGraph in possibly less than 15min

-> The two next steps are more finishing touches, and are optional (more often than not)
4 - Place the desired intermediate Waypoints, like we did with the Nodes
5 - Manually adjust the position of the few EdgeTriggers that might require it.
(override NavGraphBuilder positioning or change distance to parent Node)

As a result, some of variables doesn't need anymore to be public or accessed through the inspector.
I should soon set up custom inspectors for EdgeTriggers and Nodes to simplify the User Experience.